### PR TITLE
Fixes for a bunch of dupes

### DIFF
--- a/src/main/java/quaternary/incorporeal/feature/corporetics/block/BlockFrameTinkerer.java
+++ b/src/main/java/quaternary/incorporeal/feature/corporetics/block/BlockFrameTinkerer.java
@@ -65,7 +65,7 @@ public class BlockFrameTinkerer extends Block implements ILexiconable {
 				EntityItem ent = null;
 				ItemStack inWorldStack = null;
 				
-				List<EntityItem> itemEnts = world.getEntitiesWithinAABB(EntityItem.class, new AxisAlignedBB(pos));
+				List<EntityItem> itemEnts = world.getEntitiesWithinAABB(EntityItem.class, new AxisAlignedBB(pos), e -> e != null && !e.isDead);
 				
 				if(itemEnts.isEmpty()) {
 					inWorldStack = ItemStack.EMPTY;
@@ -86,7 +86,7 @@ public class BlockFrameTinkerer extends Block implements ILexiconable {
 				//Todo 1.13, keep in mind new item frame location possibilities.
 				List<EntityItemFrame> nearbyFrames = new ArrayList<>(2);
 				for(EnumFacing horiz : EnumFacing.HORIZONTALS) {
-					nearbyFrames.addAll(world.getEntitiesWithinAABB(EntityItemFrame.class, new AxisAlignedBB(pos.offset(horiz)))); //4 cardinal directions
+					nearbyFrames.addAll(world.getEntitiesWithinAABB(EntityItemFrame.class, new AxisAlignedBB(pos.offset(horiz)), e -> e != null && !e.isDead)); //4 cardinal directions
 				}
 				if(nearbyFrames.isEmpty()) return;
 				EntityItemFrame frame = nearbyFrames.get(world.rand.nextInt(nearbyFrames.size()));

--- a/src/main/java/quaternary/incorporeal/feature/corporetics/entity/EntityFracturedSpaceCollector.java
+++ b/src/main/java/quaternary/incorporeal/feature/corporetics/entity/EntityFracturedSpaceCollector.java
@@ -82,7 +82,7 @@ public class EntityFracturedSpaceCollector extends Entity {
 			if(age > AGE_SPECIAL_START) {
 				AxisAlignedBB aabb = new AxisAlignedBB(posX - RADIUS, posY - 1, posZ - RADIUS, posX + RADIUS, posY + 1, posZ + RADIUS);
 				List<EntityItem> nearbyItemEnts = world.getEntitiesWithinAABB(EntityItem.class, aabb, (ent) -> {
-					return ent != null && MathHelper.pointDistancePlane(ent.posX, ent.posZ, posX, posZ) <= RADIUS;
+					return ent != null && !ent.isDead && MathHelper.pointDistancePlane(ent.posX, ent.posZ, posX, posZ) <= RADIUS;
 				});
 				
 				//Succ into the wormhole

--- a/src/main/java/quaternary/incorporeal/feature/corporetics/flower/SubTileSanvocalia.java
+++ b/src/main/java/quaternary/incorporeal/feature/corporetics/flower/SubTileSanvocalia.java
@@ -63,7 +63,7 @@ public class SubTileSanvocalia extends SubTileFunctional implements ILexiconable
 		
 		AxisAlignedBB itemDetectionBox = new AxisAlignedBB(pos.add(-getRange(), 0, -getRange()), pos.add(getRange() + 1, 1, getRange() + 1));
 		List<EntityItem> nearbyTickets = w.getEntitiesWithinAABB(EntityItem.class, itemDetectionBox, (ent) -> {
-			if(ent == null) return false;
+			if(ent == null || ent.isDead) return false;
 			
 			ItemStack stack = ent.getItem/*Stack*/();
 			return ItemCorporeaTicket.hasRequest(stack);


### PR DESCRIPTION
This pull request includes fixes for dupes caused by Fractured Space Rod and Frame Tinkerer.

Frame Tinkerer example https://www.youtube.com/watch?v=rocbJMdYKNM
Rod example https://www.youtube.com/watch?v=pg1y6blg4iU

Those dupes are result of missing checks for removed item entities.